### PR TITLE
refactor(notifications): replace WebSocket with FCM push notifications

### DIFF
--- a/Monitor_Venus/src/components/forms/auth/LoginForm.vue
+++ b/Monitor_Venus/src/components/forms/auth/LoginForm.vue
@@ -114,6 +114,7 @@ import { useResponsiveView } from '@composables/useResponsiveView.js'
 import API from '@utils/api/index.js'
 import {paths}  from '@/plugins/router/paths.js'
 import GoogleLoginButton from '@/components/common/GoogleLoginButton.vue'
+import { registerPush } from '@composables/usePushNotifications.js'
 
 // Router instance
 const router = useRouter()
@@ -238,7 +239,10 @@ const handleLogin = async () => {
     }
     
     success.value = '¡Login exitoso! Redirigiendo...'
-    
+
+    // Register push notifications before redirect (shows browser permission prompt)
+    await registerPush()
+
     // Redirigir según el estado del usuario
     setTimeout(() => {
       // 1. Verificar si necesita configurar tenant

--- a/Monitor_Venus/src/components/forms/inbox/InboxForm.vue
+++ b/Monitor_Venus/src/components/forms/inbox/InboxForm.vue
@@ -537,7 +537,7 @@ function handleSortBy(field) { sortField.value = field; }
 function toggleSortDirection() { sortAscending.value = !sortAscending.value; }
 
 // WebSocket notifications: refresh tickets when any notification arrives
-const { notifications, isConnected, connectionStatus } = useNotifications();
+const { notifications, isConnected, reconnectAttempts } = useNotifications();
 let refreshTimeout = null;
 watch(() => notifications.value[0], () => {
   // Debounce: refresh 700ms after last notification

--- a/Monitor_Venus/src/composables/useNotifications.js
+++ b/Monitor_Venus/src/composables/useNotifications.js
@@ -1,7 +1,6 @@
-import { ref, onMounted, onUnmounted, computed } from 'vue';
+import { ref, onMounted, computed } from 'vue';
 import { Capacitor } from '@capacitor/core';
 import { LocalNotifications } from '@capacitor/local-notifications';
-import API from '@/utils/api/api';
 
 /**
  * Notification type definition
@@ -14,105 +13,11 @@ import API from '@/utils/api/api';
 
 export function useNotifications() {
     const notifications = ref([]);
-    const connectionStatus = ref('disconnected');
-    let websocket = null;
-    const reconnectAttempts = ref(0);
-    const maxReconnectAttempts = 10;
-    let reconnectTimeout = null;
-
-    const isConnected = computed(() => connectionStatus.value === 'connected');
     const unreadCount = computed(() => notifications.value.length);
 
-    const connect = () => {
-        // Get token from API class
-        const token = API.getValidToken();
-        
-        if (!token) {
-            console.warn('⚠️ No token available for WebSocket connection');
-            return;
-        }
-
-        // Clear any existing reconnect timeout
-        if (reconnectTimeout) {
-            clearTimeout(reconnectTimeout);
-            reconnectTimeout = null;
-        }
-
-        connectionStatus.value = 'connecting';
-
-        // Build WebSocket URL with token parameter
-        const wsBaseUrl = import.meta.env.VITE_WS_NOTIFY_URL || 'ws://localhost:5000/ws/notifications';
-        const wsUrl = `${wsBaseUrl}?token=${token}`;
-
-        console.log('🔔 Connecting to notification WebSocket:', wsBaseUrl);
-
-        try {
-            websocket = new WebSocket(wsUrl);
-
-            websocket.onopen = () => {
-                console.log('✅ Notification WebSocket connected');
-                connectionStatus.value = 'connected';
-                reconnectAttempts.value = 0;
-            };
-
-            websocket.onmessage = async (event) => {
-                try {
-                    const notification = JSON.parse(event.data);
-                    
-                    // Add notification to the list (keep last 50)
-                    notifications.value = [notification, ...notifications.value].slice(0, 50);
-
-                    // Show notification (native or browser)
-                    await showNotification(notification);
-                } catch (error) {
-                    console.error('Error parsing notification:', error);
-                }
-            };
-
-            websocket.onerror = (error) => {
-                console.error('❌ Notification WebSocket error:', error);
-                connectionStatus.value = 'disconnected';
-            };
-
-            websocket.onclose = (event) => {
-                console.log('🔴 Notification WebSocket closed:', event.code, event.reason);
-                connectionStatus.value = 'disconnected';
-                websocket = null;
-
-                // Auto-reconnect if not a normal closure and under max attempts
-                if (event.code !== 1000 && reconnectAttempts.value < maxReconnectAttempts) {
-                    reconnectAttempts.value++;
-                    const delay = Math.min(1000 * Math.pow(2, reconnectAttempts.value), 30000); // Exponential backoff, max 30s
-                    console.log(`🔄 Reconnecting notification WebSocket in ${delay}ms (attempt ${reconnectAttempts.value}/${maxReconnectAttempts})`);
-                    
-                    connectionStatus.value = 'connecting';
-                    reconnectTimeout = setTimeout(() => {
-                        connect();
-                    }, delay);
-                }
-            };
-
-        } catch (error) {
-            console.error('❌ Error creating notification WebSocket:', error);
-            connectionStatus.value = 'disconnected';
-        }
-    };
-
-    const disconnect = () => {
-        if (reconnectTimeout) {
-            clearTimeout(reconnectTimeout);
-            reconnectTimeout = null;
-        }
-
-        if (websocket) {
-            console.log('🔌 Disconnecting notification WebSocket');
-            websocket.close(1000, 'Client disconnect');
-            websocket = null;
-        }
-        
-        connectionStatus.value = 'disconnected';
-        reconnectAttempts.value = 0;
-    };
+    // Always connected — FCM push notifications replaced the WebSocket transport.
+    const isConnected = computed(() => true);
+    const reconnectAttempts = computed(() => 0);
 
     const clearNotifications = () => {
         notifications.value = [];
@@ -127,10 +32,8 @@ export function useNotifications() {
      */
     const showNotification = async (notification) => {
         if (Capacitor.isNativePlatform()) {
-            // Native platform - use LocalNotifications with heads-up display
             await showNativeNotification(notification);
         } else {
-            // Browser - use Web Notifications API
             await showBrowserNotification(notification);
         }
     };
@@ -141,7 +44,7 @@ export function useNotifications() {
     const showNativeNotification = async (notification) => {
         try {
             const permission = await LocalNotifications.checkPermissions();
-            
+
             if (permission.display !== 'granted') {
                 return;
             }
@@ -183,7 +86,6 @@ export function useNotifications() {
                 requireInteraction: false
             };
 
-            // Use Service Worker for mobile browsers (required)
             if ('serviceWorker' in navigator) {
                 const registration = await navigator.serviceWorker.ready;
                 await registration.showNotification(notification.title, {
@@ -191,7 +93,6 @@ export function useNotifications() {
                     vibrate: [200, 100, 200]
                 });
             } else {
-                // Fallback for desktop browsers
                 new Notification(notification.title, options);
             }
         } catch (error) {
@@ -209,12 +110,11 @@ export function useNotifications() {
 
         try {
             const permission = await Notification.requestPermission();
-            
-            // Ensure Service Worker is ready for mobile
+
             if (permission === 'granted' && 'serviceWorker' in navigator) {
                 await navigator.serviceWorker.ready;
             }
-            
+
             return permission === 'granted';
         } catch (error) {
             console.error('Error requesting notification permission:', error);
@@ -223,7 +123,6 @@ export function useNotifications() {
     };
 
     onMounted(async () => {
-        // Create notification channel for Android
         if (Capacitor.isNativePlatform() && Capacitor.getPlatform() === 'android') {
             try {
                 await LocalNotifications.createChannel({
@@ -243,23 +142,16 @@ export function useNotifications() {
         }
 
         await requestNotificationPermission();
-        // connect(); // Disabled: replaced by Firebase Cloud Messaging
-    });
-
-    onUnmounted(() => {
-        disconnect();
     });
 
     return {
         notifications,
         isConnected,
-        connectionStatus,
         unreadCount,
         reconnectAttempts,
         clearNotifications,
         removeNotification,
-        requestNotificationPermission,
-        connect,
-        disconnect
+        showNotification,
+        requestNotificationPermission
     };
 }

--- a/Monitor_Venus/src/composables/usePushNotifications.js
+++ b/Monitor_Venus/src/composables/usePushNotifications.js
@@ -8,7 +8,7 @@ const isNative = Capacitor.isNativePlatform()
 
 const fcmToken = ref(null)
 const deviceId = ref(localStorage.getItem('push_device_id') || null)
-const isRegistered = ref(false)
+const isRegistered = ref(!!localStorage.getItem('push_device_id'))
 
 function persistDeviceId(id) {
   deviceId.value = id
@@ -43,8 +43,8 @@ export async function registerPush() {
     return false
   }
 
-  if (isRegistered.value) {
-    console.log('Push already registered')
+  if (isRegistered.value && deviceId.value) {
+    console.log('Push already registered, device:', deviceId.value)
     return true
   }
 

--- a/Monitor_Venus/src/layouts/default.vue
+++ b/Monitor_Venus/src/layouts/default.vue
@@ -21,8 +21,8 @@ import { createAnimation } from '@ionic/vue'
 
 /**
  * Initialize global notification system
- * - WebSocket connection persists across all routes
- * - Available to all child components via inject('notifications')
+ * - Provides notification display helpers (showNotification, etc.) to all child components
+ * - Available via inject('notifications')
  */
 const notificationSystem = useNotifications()
 provide('notifications', notificationSystem)

--- a/Monitor_Venus/src/views/home/index.vue
+++ b/Monitor_Venus/src/views/home/index.vue
@@ -325,7 +325,6 @@
 import { ref, computed, onMounted, onUnmounted, inject, watch } from 'vue'
 import { useRouter, onBeforeRouteLeave } from 'vue-router'
 import { useAuthStore } from '@/stores/authStore.js'
-import { useNotifications } from '@/composables/useNotifications.js'
 import API from '@/utils/api/api.js'
 import { paths as P } from '@/plugins/router/paths.js'
 
@@ -338,7 +337,6 @@ import { statsChartOutline, timeOutline, serverOutline, peopleOutline, mailOutli
 const router = useRouter()
 const authStore = useAuthStore()
 const icons = inject('icons', {})
-const { connectionStatus, connect, disconnect } = useNotifications()
 
 // Recent Activity from API (Audit logs)
 const serverActivity = ref([])
@@ -493,18 +491,11 @@ const platformLabel = computed(() => {
   return 'Unknown Platform'
 })
 
-// System status based on notification connection
-const systemStatus = computed(() => {
-  if (connectionStatus.value === 'connected') return 'All Systems Operational'
-  if (connectionStatus.value === 'connecting') return 'Connecting...'
-  return 'Connection Lost'
-})
+// System status — FCM push notifications replaced the WebSocket connection,
+// so the "connected" state is always assumed.
+const systemStatus = computed(() => 'All Systems Operational')
 
-const systemStatusColor = computed(() => {
-  if (connectionStatus.value === 'connected') return 'success'
-  if (connectionStatus.value === 'connecting') return 'warning'
-  return 'danger'
-})
+const systemStatusColor = computed(() => 'success')
 
 // Real-time metrics from API
 const metrics = ref([
@@ -691,10 +682,7 @@ const navigateTo = (path) => {
 onMounted(async () => {
   isMounted.value = true
   pageReady.value = true
-  
-  // Connect to notification WebSocket
-  connect()
-  
+
   // Fetch real metrics
   await fetchMetrics()
   
@@ -709,7 +697,6 @@ onMounted(async () => {
   onUnmounted(() => {
     isMounted.value = false
     clearInterval(metricsInterval)
-    disconnect()
   })
 })
 


### PR DESCRIPTION
Migrate the notification system from a WebSocket-based implementation to Firebase Cloud Messaging (FCM). This change simplifies the connection management by removing the need for persistent WebSocket connections and manual reconnection logic.

- Remove WebSocket connection logic from `useNotifications` and `home/index.vue`
- Integrate `registerPush` into the `LoginForm` to request permissions upon login
- Update `usePushNotifications` to improve registration state persistence
- Simplify `systemStatus` in the home view to reflect the new push-based architecture
- Update `InboxForm` to use `reconnectAttempts` instead of `connectionStatus`